### PR TITLE
feat(logging): add WCLoggerAdapter for gateway logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Unreleased]
 
+## [3.2.1] - 2026-02-26
+- Add logger adapter to use in gateway logs.
+
 ## [3.2.0] - 2026-02-24
 - Set expiration time to 30 minutes by default.
 - Update tracing information in logs (level and context).

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Usage:
-# make compile PLUGIN_VERSION=3.2.0
+# make compile PLUGIN_VERSION=3.2.1
 
 .PHONY: compile
 compile:

--- a/src/GatewayMethod.php
+++ b/src/GatewayMethod.php
@@ -18,6 +18,7 @@ use PlacetoPay\PaymentMethod\Constants\Country;
 use PlacetoPay\PaymentMethod\Constants\Discount;
 use PlacetoPay\PaymentMethod\Constants\Environment;
 use PlacetoPay\PaymentMethod\Constants\Rules;
+use PlacetoPay\PaymentMethod\Logger\WCLoggerAdapter;
 use stdClass;
 use WC_HTTPS;
 use WC_Order;
@@ -28,7 +29,7 @@ use WC_Payment_Gateway;
  */
 class GatewayMethod extends WC_Payment_Gateway
 {
-    const VERSION = '3.2.0';
+    const VERSION = '3.2.1';
 
     const META_AUTHORIZATION_CUS = '_p2p_authorization';
 
@@ -75,7 +76,12 @@ class GatewayMethod extends WC_Payment_Gateway
     /**
      * @var \WC_Logger
      */
-    private $log;
+    private $logger;
+
+    /**
+     * @var ?Psr\Log\LoggerInterface
+     */
+    private $loggerAdapter;
 
     private $expiration_time_minutes;
 
@@ -1255,7 +1261,7 @@ class GatewayMethod extends WC_Payment_Gateway
             $message .= ' | Context: ' . json_encode($context, JSON_UNESCAPED_UNICODE);
         }
 
-        $this->log->add(
+        $this->logger->add(
             CountryConfig::CLIENT_ID,
             strtoupper($level) . ($type ? " ($type): " : ': ') . $message
         );
@@ -1507,7 +1513,7 @@ class GatewayMethod extends WC_Payment_Gateway
         $domain = $_SERVER['HTTP_HOST'] ?? ($_SERVER['SERVER_NAME'] ?? 'localhost');
 
         return [
-            'User-Agent' => "woocommerce-gateway-translations/{$this->version} (origin:$domain; vr:" . WOOCOMMERCE_VERSION . ')',
+            'User-Agent' => "woocommerce-gateway-placetopay/{$this->version} (origin:$domain; vr:" . WOOCOMMERCE_VERSION . ')',
             'X-Source-Platform' => 'woocommerce',
         ];
     }
@@ -1523,6 +1529,7 @@ class GatewayMethod extends WC_Payment_Gateway
             'tranKey' => $this->tran_key,
             'baseUrl' => $this->uri_service,
             'headers' => $this->getHeaders(),
+            'logger' => $this->loggerAdapter,
         ];
 
         try {
@@ -1646,9 +1653,11 @@ class GatewayMethod extends WC_Payment_Gateway
             : 'no';
 
         if ($this->testmode === 'yes') {
-            $this->log = self::wooCommerceVersionCompare('2.1')
+            $this->logger = self::wooCommerceVersionCompare('2.1')
                 ? new \WC_Logger()
                 : WC()->logger();
+
+            $this->loggerAdapter = new WCLoggerAdapter($this->logger, CountryConfig::CLIENT_ID);
         }
 
         if ($this->enviroment_mode === Environment::CUSTOM) {

--- a/src/Logger/WCLoggerAdapter.php
+++ b/src/Logger/WCLoggerAdapter.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace PlacetoPay\PaymentMethod\Logger;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+
+class WCLoggerAdapter implements LoggerInterface
+{
+    private $logger;
+
+    private $source;
+
+    public function __construct(\WC_Logger $logger, string $source = 'placetopay')
+    {
+        $this->logger = $logger;
+        $this->source = $source;
+    }
+
+    public function emergency($message, array $context = []): void
+    {
+        $this->log(LogLevel::EMERGENCY, $message, $context);
+    }
+
+    public function alert($message, array $context = []): void
+    {
+        $this->log(LogLevel::ALERT, $message, $context);
+    }
+
+    public function critical($message, array $context = []): void
+    {
+        $this->log(LogLevel::CRITICAL, $message, $context);
+    }
+
+    public function error($message, array $context = []): void
+    {
+        $this->log(LogLevel::ERROR, $message, $context);
+    }
+
+    public function warning($message, array $context = []): void
+    {
+        $this->log(LogLevel::WARNING, $message, $context);
+    }
+
+    public function notice($message, array $context = []): void
+    {
+        $this->log(LogLevel::NOTICE, $message, $context);
+    }
+
+    public function info($message, array $context = []): void
+    {
+        $this->log(LogLevel::INFO, $message, $context);
+    }
+
+    public function debug($message, array $context = []): void
+    {
+        $this->log(LogLevel::DEBUG, $message, $context);
+    }
+
+    public function log($level, $message, array $context = []): void
+    {
+        $message = $this->normalizeMessage($message);
+        $message = $this->interpolate($message, $context);
+
+        if ($context !== []) {
+            $message .= ' | context=' . json_encode($context, JSON_UNESCAPED_UNICODE);
+        }
+
+        $this->logger->add($this->source, strtoupper((string) $level) . ': ' . $message);
+    }
+
+    private function normalizeMessage($message): string
+    {
+        if (is_string($message)) {
+            return $message;
+        }
+
+        return json_encode($message, JSON_UNESCAPED_UNICODE);
+    }
+
+    private function interpolate(string $message, array $context): string
+    {
+        if (strpos($message, '{') === false) {
+            return $message;
+        }
+
+        $replace = [];
+
+        foreach ($context as $key => $value) {
+            if (is_array($value) || is_object($value)) {
+                $value = json_encode($value, JSON_UNESCAPED_UNICODE);
+            }
+
+            $replace['{' . $key . '}'] = (string) $value;
+        }
+
+        return strtr($message, $replace);
+    }
+}


### PR DESCRIPTION
Introduce a PSR-3 logger adapter for WooCommerce logs, enabling structured logging and improved context handling in gateway operations. Update version to 3.2.1 and adjust headers for PlacetoPay service requests.